### PR TITLE
Typenames need to be assemblyqualified

### DIFF
--- a/DotNet/eMandates.Merchant.Library/XML/Utils/RSAPKCS1SHA256SignatureDescription.cs
+++ b/DotNet/eMandates.Merchant.Library/XML/Utils/RSAPKCS1SHA256SignatureDescription.cs
@@ -82,7 +82,7 @@ namespace eMandates.Merchant.Library.XML.Utils
         /// </summary>
         public RSAPKCS1SHA256SignatureDescription()
         {
-            KeyAlgorithm = typeof(RSA).FullName;
+            KeyAlgorithm = typeof(RSA).AssemblyQualifiedName;
             DigestAlgorithm = typeof(SHA256Managed).FullName;   // Note - SHA256CryptoServiceProvider is not registered with CryptoConfig
             FormatterAlgorithm = typeof(RSAPKCS1SignatureFormatter).FullName;
             DeformatterAlgorithm = typeof(RSAPKCS1SignatureDeformatter).FullName;


### PR DESCRIPTION
The library didn't work, because the GetType in SingedXml couldn't find the RSA class without namespace qualification.